### PR TITLE
added explicit license stating that this code is public domain

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>


### PR DESCRIPTION
First of all, thank you for the excellent sample, I learnt a lot from it!

I saw your statement:

> "For the eager reader, we provide a sample iOS app project which has NO license attached so feel free to do whatever you want with it." (https://github.com/light-tech/LLVM-On-iOS)

Unfortunately, despite best intentions, the result is exactly opposite, since the absence of license is extremely problematic in many (most? all?) jurisdictions. If you would like to grant users the freedom to use, modify, and distribute the project, you need to attach a permissive open-source license to the project. The most permissive popular license is the so-called [Unlicense](https://unlicense.org) which effectively states that the code is public domain and everyone can use it freely for any purpose. It would be great if you included it (or any other permissive open source license, if you prefer any other).

Thanks a lot!